### PR TITLE
Added asFloat asInteger and _innerValue methods

### DIFF
--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -770,6 +770,37 @@ class Decimal
     }
 
     /**
+     * Return value as a float
+     *
+     * @return float
+     */
+    public function asFloat()
+    {
+        return floatval($this->value);
+    }
+
+    /**
+     * Return value as a integer
+     *
+     * @return float
+     */
+    public function asInteger()
+    {
+        return intval($this->value);
+    }
+
+    /**
+     * Return the inner representation of the class
+     * use with caution
+     *
+     * @return number
+     */
+    public function _innerValue()
+    {
+        return $this->value;
+    }
+
+    /**
      * @return string
      */
     public function __toString()

--- a/tests/Decimal/DecimalAsFloatTest.php
+++ b/tests/Decimal/DecimalAsFloatTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Litipk\BigNumbers\Decimal as Decimal;
+
+
+date_default_timezone_set('UTC');
+
+
+class DecimalAsFloatTest extends PHPUnit_Framework_TestCase
+{
+    public function testFloat()
+    {
+        $this->assertEquals(1.0, Decimal::fromString('1.0')->asFloat());
+        $this->assertTrue(is_float(Decimal::fromString('1.0')->asFloat()));
+
+        $this->assertEquals(1.0, Decimal::fromInteger(1)->asFloat());
+        $this->assertTrue(is_float(Decimal::fromInteger(1)->asFloat()));
+
+        $this->assertEquals(1.0, Decimal::fromFloat(1.0)->asFloat());
+        $this->assertEquals(1.123123123, Decimal::fromString('1.123123123')->asFloat());
+
+        $this->assertTrue(is_float(Decimal::fromFloat(1.0)->asFloat()));
+        $this->assertTrue(is_float(Decimal::fromString('1.123123123')->asFloat()));
+    }
+}

--- a/tests/Decimal/DecimalAsIntegerTest.php
+++ b/tests/Decimal/DecimalAsIntegerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Litipk\BigNumbers\Decimal as Decimal;
+
+
+date_default_timezone_set('UTC');
+
+
+class DecimalAsIntegerTest extends PHPUnit_Framework_TestCase
+{
+    public function testFloat()
+    {
+        $this->assertEquals(1, Decimal::fromString('1.0')->asInteger());
+        $this->assertTrue(is_int(Decimal::fromString('1.0')->asInteger()));
+
+        $this->assertEquals(1, Decimal::fromInteger(1)->asInteger());
+        $this->assertTrue(is_int(Decimal::fromInteger(1)->asInteger()));
+
+        $this->assertEquals(1, Decimal::fromFloat(1.0)->asInteger());
+        $this->assertEquals(1, Decimal::fromString('1.123123123')->asInteger());
+
+        $this->assertTrue(is_int(Decimal::fromFloat(1.0)->asInteger()));
+        $this->assertTrue(is_int(Decimal::fromString('1.123123123')->asInteger()));
+    }
+}

--- a/tests/Decimal/DecimalInnerValueTest.php
+++ b/tests/Decimal/DecimalInnerValueTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Litipk\BigNumbers\Decimal as Decimal;
+
+
+date_default_timezone_set('UTC');
+
+
+class DecimalInnerValueTest extends PHPUnit_Framework_TestCase
+{
+    public function testInnerValue()
+    {
+        for($i=0;$i<100;$i++)
+        {
+            $this->assertEquals($i, Decimal::fromInteger($i)->_innerValue());
+        }
+    }
+}


### PR DESCRIPTION
> And.. another point, I don't remember how PHP strings work, but we should ensure that if someone modifies the string outside the object, the inner string isn't modified (so, we must ensure we return a copy, not a reference to the inner object, because that's "dangerous").

Don't worry about that. The value return is just a copy of the value not a reference.
