### PR TITLE
Fixed truncation when scale not passed to comp()

### DIFF
--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -545,10 +545,12 @@ class Decimal
             return -$b->comp($this);
         }
 
+        $cmp_scale = $scale !== null ? $scale : max($this->scale, $b->scale);
+
         return bccomp(
-            self::innerRound($this->value, $scale),
-            self::innerRound($b->value, $scale),
-            $scale
+            self::innerRound($this->value, $cmp_scale),
+            self::innerRound($b->value, $cmp_scale),
+            $cmp_scale
         );
     }
 

--- a/tests/Decimal/DecimalCompTest.php
+++ b/tests/Decimal/DecimalCompTest.php
@@ -22,4 +22,59 @@ class DecimalCompTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($one->comp($ten) === -1);
         $this->assertTrue($ten->comp($one) === 1);
     }
+
+    public function testUnscaledComp()
+    {
+        // Transitivity
+        $this->assertEquals(-1, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.01)));
+        $this->assertEquals(1, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.004)));
+        $this->assertEquals(-1, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.004)));
+
+        // Reflexivity
+        $this->assertEquals(0, Decimal::fromFloat(1.00525)->comp(Decimal::fromFloat(1.00525)));
+
+        // Symmetry
+        $this->assertEquals(1, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.001)));
+        $this->assertEquals(-1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.01)));
+        $this->assertEquals(1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.001)));
+
+        $this->assertEquals(1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.000)));
+
+        // Warning, float to Decimal conversion can have unexpected behaviors, like converting
+        // 1.005 to Decimal("1.0049999999999999")
+        $this->assertEquals(-1, Decimal::fromFloat(1.0050000000001)->comp(Decimal::fromFloat(1.010)));
+
+        $this->assertEquals(-1, Decimal::fromString("1.005")->comp(Decimal::fromString("1.010")));
+
+        # Proper rounding
+        $this->assertEquals(-1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.0050000000001)));
+    }
+
+    public function testScaledComp()
+    {
+        // Transitivity
+        $this->assertEquals(0, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.01), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.004), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.004), 1));
+
+        // Reflexivity
+        $this->assertEquals(0, Decimal::fromFloat(1.00525)->comp(Decimal::fromFloat(1.00525), 2));
+
+        // Symmetry
+        $this->assertEquals(0, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.001), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.01), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.001), 1));
+
+        // Proper rounding
+        $this->assertEquals(0, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.000), 2));
+
+        // Warning, float to Decimal conversion can have unexpected behaviors, like converting
+        // 1.005 to Decimal("1.0049999999999999")
+        $this->assertEquals(0, Decimal::fromFloat(1.0050000000001)->comp(Decimal::fromFloat(1.010), 2));
+
+        $this->assertEquals(0, Decimal::fromString("1.005")->comp(Decimal::fromString("1.010"), 2));
+
+        # Proper rounding
+        $this->assertEquals(-1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.0050000000001), 2));
+    }
 }


### PR DESCRIPTION
Ran in to some surprising behaviour when scale is not passed to `comp()` in master:
```php
var_dump(Decimal::create("1.234")->comp(Decimal::create("1.235")));
// int(0)!
```

I've updated it to be in line with how `equals()` behaves. With this PR:
```php
var_dump(Decimal::create("1.234")->comp(Decimal::create("1.235")));
// int(-1)
```