### PR TITLE
Decimal formatter

### DIFF
--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -868,6 +868,15 @@ class Decimal
     }
 
     /**
+     * Syntactic sugar: formats the decimal using a Formatter
+     */
+    public function format(array $options=[])
+    {
+        $formatter = new Formatter($options);
+        return $formatter->format($this);
+    }
+
+    /**
      * "Rounds" the decimal string to have at most $scale digits after the point
      *
      * @param  string  $value

--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -545,10 +545,12 @@ class Decimal
             return -$b->comp($this);
         }
 
+        $cmp_scale = $scale !== null ? $scale : max($this->scale, $b->scale);
+
         return bccomp(
-            self::innerRound($this->value, $scale),
-            self::innerRound($b->value, $scale),
-            $scale
+            self::innerRound($this->value, $cmp_scale),
+            self::innerRound($b->value, $cmp_scale),
+            $cmp_scale
         );
     }
 

--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -877,6 +877,14 @@ class Decimal
     }
 
     /**
+     * Syntactic sugar: formats the decimal using a registered Formatter
+     */
+    public function formatAs($format)
+    {
+        return Formatter::formatAs($format, $this);
+    }
+
+    /**
      * "Rounds" the decimal string to have at most $scale digits after the point
      *
      * @param  string  $value

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -1,0 +1,122 @@
+<?php
+namespace Litipk\BigNumbers;
+
+class Formatter
+{
+    /**
+     * Number of decimal places to round to in formatted output. Resulting 
+     * decimal portion will be zero-padded if $this->padDecimal is true
+     */
+    private $scale = null;
+
+    /**
+     * If true, decimal component will be padded with zeroes up to the length
+     * of $this->scale
+     */
+    private $padDecimal = true;
+
+    private $decimalMark = '.';
+    private $thousandsMark = ',';
+
+    /**
+     * String used for sign.
+     */
+    private $sign = '-';
+
+    /**
+     * If you want to pad {sign} with whitespace, set $this->sign instead otherwise
+     * your padding will appear in unsigned numbers too.
+     *
+     * Use this for things like currency:
+     *   format('1.234', ['tpl'=>'AUD {sign}${num}'])
+     */
+    private $tpl = '{sign}{num}';
+
+    private static $registry = [];
+
+    static function register($name, $options)
+    {
+        static::$registry[$name] = new static($options);
+    }
+
+    static function unregister($name=null)
+    {
+        if ($name) {
+            unset(static::$registry[$name]);
+        } else {
+            static::$registry = [];
+        }
+    }
+
+    static function formatAs($name, $number)
+    {
+        if (!isset(static::$registry[$name])) {
+            throw new \InvalidArgumentException("Unregistered formatter $name");
+        }
+        return static::$registry[$name]->format($number);
+    }
+
+    /**
+     * Accepts an array of keyword arguments corresponding to the following properties:
+     *   scale, decimalMark, thousandsMark, sign, tpl
+     */
+    public function __construct(array $options=[])
+    {
+        foreach ($options as $k=>$v) {
+            if (!property_exists($this, $k)) {
+                throw new \InvalidArgumentException("Unexpected keyword argument $k");
+            }
+            $this->$k = $v;
+        }
+
+        if (!$this->decimalMark) {
+            throw new \InvalidArgumentException("Decimal mark was blank");
+        }
+
+        if (!$this->sign) {
+            throw new \InvalidArgumentException("Sign was blank");
+        }
+
+        $this->thousandsMarkRev = isset($this->thousandsMark[1])
+            ? strrev($this->thousandsMark)
+            : $this->thousandsMark;
+    }
+
+    /**
+     * @param  mixed   $decimal  Anything accepted by Decimal::create
+     * @return string
+     */
+    public function format($decimal)
+    {
+        if (!$decimal instanceof Decimal) {
+            $decimal = Decimal::create($decimal);
+        }
+
+        if ($this->scale !== null) {
+            $decimal = $decimal->round($this->scale < 0 ? 0 : $this->scale);
+        }
+
+        $negative = $decimal->isNegative();
+        $decimal = $decimal->abs();
+
+        $x = explode('.', $decimal->__toString(), 2);
+        $whole = $x[0];
+        $decimal = isset($x[1]) ? $x[1] : null;
+
+        $out = strrev(implode($this->thousandsMarkRev, str_split(strrev($whole), 3)));
+
+        if ($decimal !== null) {
+            $decimalOut = $decimal;
+
+            if ($this->padDecimal) {
+                $decimalOut = str_pad($decimalOut, $this->scale, '0');
+            }
+            $out .= $this->decimalMark.$decimalOut;
+        }
+
+        return strtr($this->tpl, array(
+            '{num}'=>$out,
+            '{sign}'=>$negative ? $this->sign : '',
+        ));
+    }
+}

--- a/tests/Decimal/DecimalCompTest.php
+++ b/tests/Decimal/DecimalCompTest.php
@@ -22,4 +22,59 @@ class DecimalCompTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($one->comp($ten) === -1);
         $this->assertTrue($ten->comp($one) === 1);
     }
+
+    public function testUnscaledComp()
+    {
+        // Transitivity
+        $this->assertEquals(-1, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.01)));
+        $this->assertEquals(1, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.004)));
+        $this->assertEquals(-1, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.004)));
+
+        // Reflexivity
+        $this->assertEquals(0, Decimal::fromFloat(1.00525)->comp(Decimal::fromFloat(1.00525)));
+
+        // Symmetry
+        $this->assertEquals(1, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.001)));
+        $this->assertEquals(-1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.01)));
+        $this->assertEquals(1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.001)));
+
+        $this->assertEquals(1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.000)));
+
+        // Warning, float to Decimal conversion can have unexpected behaviors, like converting
+        // 1.005 to Decimal("1.0049999999999999")
+        $this->assertEquals(-1, Decimal::fromFloat(1.0050000000001)->comp(Decimal::fromFloat(1.010)));
+
+        $this->assertEquals(-1, Decimal::fromString("1.005")->comp(Decimal::fromString("1.010")));
+
+        # Proper rounding
+        $this->assertEquals(-1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.0050000000001)));
+    }
+
+    public function testScaledComp()
+    {
+        // Transitivity
+        $this->assertEquals(0, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.01), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.004), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.001)->comp(Decimal::fromFloat(1.004), 1));
+
+        // Reflexivity
+        $this->assertEquals(0, Decimal::fromFloat(1.00525)->comp(Decimal::fromFloat(1.00525), 2));
+
+        // Symmetry
+        $this->assertEquals(0, Decimal::fromFloat(1.01)->comp(Decimal::fromFloat(1.001), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.01), 1));
+        $this->assertEquals(0, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.001), 1));
+
+        // Proper rounding
+        $this->assertEquals(0, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.000), 2));
+
+        // Warning, float to Decimal conversion can have unexpected behaviors, like converting
+        // 1.005 to Decimal("1.0049999999999999")
+        $this->assertEquals(0, Decimal::fromFloat(1.0050000000001)->comp(Decimal::fromFloat(1.010), 2));
+
+        $this->assertEquals(0, Decimal::fromString("1.005")->comp(Decimal::fromString("1.010"), 2));
+
+        # Proper rounding
+        $this->assertEquals(-1, Decimal::fromFloat(1.004)->comp(Decimal::fromFloat(1.0050000000001), 2));
+    }
 }

--- a/tests/Decimal/DecimalFormatTest.php
+++ b/tests/Decimal/DecimalFormatTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Litipk\BigNumbers\Decimal as Decimal;
+
+
+date_default_timezone_set('UTC');
+
+
+class DecimalFormatTest extends PHPUnit_Framework_TestCase
+{
+    public function testFormat()
+    {
+        $this->assertSame('1,234,567.89' , Decimal::create('1234567.89')->format());
+        $this->assertSame('1,234,567.890', Decimal::create('1234567.89')->format(['scale'=>3]));
+    }
+}

--- a/tests/Decimal/DecimalFormatTest.php
+++ b/tests/Decimal/DecimalFormatTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Litipk\BigNumbers\Decimal as Decimal;
+use Litipk\BigNumbers\Formatter as Formatter;
 
 
 date_default_timezone_set('UTC');
@@ -8,9 +9,20 @@ date_default_timezone_set('UTC');
 
 class DecimalFormatTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        Formatter::unregister();
+    }
+
     public function testFormat()
     {
         $this->assertSame('1,234,567.89' , Decimal::create('1234567.89')->format());
         $this->assertSame('1,234,567.890', Decimal::create('1234567.89')->format(['scale'=>3]));
+    }
+
+    public function testFormatAs()
+    {
+        Formatter::register('pants', ['thousandsMark'=>'*', 'decimalMark'=>'^']);
+        $this->assertSame('1*234*567^89' , Decimal::create('1234567.89')->formatAs('pants'));
     }
 }

--- a/tests/Formatter/FormatterRegistryTest.php
+++ b/tests/Formatter/FormatterRegistryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Litipk\BigNumbers\Decimal as Decimal;
+use Litipk\BigNumbers\Formatter as Formatter;
+
+class FormatterRegistryTest extends PHPUnit_Framework_TestCase
+{
+    function setUp()
+    {
+        Formatter::unregister();
+    }
+
+    public function testRegistry()
+    {
+        Formatter::register('pants', ['thousandsMark'=>'!', 'decimalMark'=>'%%%']);
+        $this->assertSame('1!234!567%%%890', Formatter::formatAs('pants', '1234567.890'));
+    }
+
+    public function testRegistryInvalid()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        Formatter::formatAs('pants', '1234567.890');
+    }
+
+    public function testRegistryUnregister()
+    {
+        Formatter::register('pants', ['thousandsMark'=>'!', 'decimalMark'=>'%%%']);
+        Formatter::unregister('pants');
+        $this->setExpectedException('InvalidArgumentException');
+        Formatter::formatAs('pants', '1234567.890');
+    }
+}

--- a/tests/Formatter/FormatterTest.php
+++ b/tests/Formatter/FormatterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use Litipk\BigNumbers\Decimal as Decimal;
+use Litipk\BigNumbers\Formatter as Formatter;
+
+class FormatterTest extends PHPUnit_Framework_TestCase
+{
+    function dataFormat()
+    {
+        return [
+            // Decimal class doesn't accept these as input yet.
+            // ['0.234', '.234'),
+            // ['-0.234', '-.234'),
+
+            ['0.234', '0.234'],
+            ['-0.234', '-0.234'],
+
+            ['-1.234', '-1.234'],
+            ['-11.234', '-11.234'],
+            ['-101.234', '-101.234'],
+            ['-1,001.234', '-1001.234'],
+            ['-10,001.234', '-10001.234'],
+            ['-100,001.234', '-100001.234'],
+            ['-1,000,001.234', '-1000001.234'],
+
+            ['1.234', '1.234'],
+            ['11.234', '11.234'],
+            ['101.234', '101.234'],
+            ['1,001.234', '1001.234'],
+            ['10,001.234', '10001.234'],
+            ['100,001.234', '100001.234'],
+            ['1,000,001.234', '1000001.234'],
+        ];
+    }
+
+    /** @dataProvider dataFormat */
+    public function testFormat($expected, $input)
+    {
+        $this->assertFormat($expected, $input);
+    }
+
+    public function testFormatInvalidConstructorArg()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new Formatter(['abcdefg'=>true]);
+    }
+
+    public function testFormatBadInput()
+    {
+        $this->setExpectedException("InvalidArgumentException");
+        $this->format("abcdefgh", []);
+    }
+
+    public function testFormatScaleRounds()
+    {
+        $this->assertFormat('1.6', '1.56', ['scale'=>1]);
+    }
+
+    public function testZeroPaddedDecimal()
+    {
+        $this->assertFormat('1.23000', '1.23', ['scale'=>5]);
+    }
+
+    public function testNoZeroPaddedDecimal()
+    {
+        $this->assertFormat('1.23', '1.23', ['scale'=>5, 'padDecimal'=>false]);
+    }
+
+    public function testFormatBlankThousandsMark()
+    {
+        $this->assertFormat('1000', '1000', ['thousandsMark'=>'']);
+    }
+
+    public function testFormatBlankDecimalMark()
+    {
+        $this->setExpectedException("InvalidArgumentException");
+        $this->format('1.234', ['decimalMark'=>'']);
+    }
+
+    public function testFormatDecimalMark()
+    {
+        $this->assertFormat('1,234', '1.234', ['decimalMark'=>","]);
+    }
+
+    public function testFormatThousandsMark()
+    {
+        $this->assertFormat("1 '000 '234", '1000234', ['thousandsMark'=>" '"]);
+    }
+
+    public function testFormatBlankSign()
+    {
+        $this->setExpectedException("InvalidArgumentException");
+        $this->format('-1.234', ['sign'=>'']);
+    }
+
+    public function testFormatSign()
+    {
+        $this->assertFormat('- 1.234', '-1.234', ['sign'=>'- ']);
+    }
+
+    public function testTemplate()
+    {
+        $options = ['sign'=>' -', 'tpl'=>'${num}{sign} !!!'];
+        $this->assertFormat('$1,000,000.25 - !!!', '-1000000.25', $options);
+        $this->assertFormat('$1,000,000.25 !!!'  ,  '1000000.25', $options);
+    }
+
+    function format($number, $options=[])
+    {
+        $formatter = new Formatter($options);
+        return $formatter->format($number);
+    }
+
+    function assertFormat($expected, $input, $options=[])
+    {
+        $this->assertSame($expected, $this->format($input, $options));
+    }
+}

--- a/tests/Formatter/FormatterTest.php
+++ b/tests/Formatter/FormatterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Litipk\BigNumbers\Decimal as Decimal;
+use Litipk\BigNumbers\InfiniteDecimal as InfiniteDecimal;
 use Litipk\BigNumbers\Formatter as Formatter;
 
 class FormatterTest extends PHPUnit_Framework_TestCase
@@ -103,6 +104,17 @@ class FormatterTest extends PHPUnit_Framework_TestCase
         $options = ['sign'=>' -', 'tpl'=>'${num}{sign} !!!'];
         $this->assertFormat('$1,000,000.25 - !!!', '-1000000.25', $options);
         $this->assertFormat('$1,000,000.25 !!!'  ,  '1000000.25', $options);
+    }
+
+    public function testInfiniteDecimal()
+    {
+        $formatter = new Formatter();
+
+        $inf = InfiniteDecimal::getPositiveInfinite();
+        $this->assertEquals('INF', $formatter->format($inf));
+
+        $inf = InfiniteDecimal::getNegativeInfinite();
+        $this->assertEquals('-INF', $formatter->format($inf));
     }
 
     function format($number, $options=[])


### PR DESCRIPTION
I ran into an issue where I started using Decimal objects but my views were using a variant of `number_format`, so I've written a simple Formatter class for Decimal which I figured I should offer back to the project. I originally made it a method directly on Decimal, but it got ugly pretty fast and then I remembered that there are countries in the world that aren't Australia!

I tried to find a flexible middle-ground between the clumsiness of `number_format` and the incredible completeness of `NumberFormatter` (which would be way too much work to replicate). Hopefully you find this a useful addition.

``` php
// basic usage:
$f = new \Litipk\BigNumbers\Formatter();
echo $f->format("1234567.89");
echo $f->format(\Litipk\BigNumbers\Decimal::create("1234567.89"));
// "1,234,567.89"

// customisable:
$f = new \Litipk\BigNumbers\Formatter([
    'thousandsMark'=>"'",
    'decimalMark'=>',',
    'padDecimal'=>false,
    'tpl'=>'YEAH! {num}{sign} !!!',
    'sign'=>' -',
    'scale'=>5,
]);
echo $f->format(\Litipk\BigNumbers\Decimal::create("-1234567.89"));
// "YEAH! 1'234'567,89 - !!!"
```

I added a simple registry so you can store formats as you please for easy access:

``` php
Formatter::register('aud', ['scale'=>2, 'tpl'=>'AUD ${sign}{num}']);
Formatter::formatAs('aud', '1.234');
Formatter::formatAs('aud', \Litipk\BigNumbers\Decimal::create('1.234'));
// "AUD $1.23"
```

There's some syntactic sugar too, i.e. you can also call `Decimal->format($options)` and `Decimal->formatAs($registered)`, but all it does is delegate to the formatter.
