### PR TITLE
Add convenient comparison methods isGreaterThan() etc.

### DIFF
--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -455,6 +455,59 @@ class Decimal
         );
     }
 
+
+    /**
+     * Returns true if $this > $b, otherwise false
+     *
+     * @param  Decimal $b
+     * @param  integer $scale
+     * @return bool
+     */
+    public function isGreaterThan(Decimal $b, int $scale = null): bool
+    {
+        return $this->comp($b, $scale) === 1;
+    }
+
+    /**
+     * Returns true if $this >= $b
+     *
+     * @param  Decimal $b
+     * @param  integer $scale
+     * @return bool
+     */
+    public function isGreaterOrEqualTo(Decimal $b, int $scale = null): bool
+    {
+        $comparisonResult = $this->comp($b, $scale);
+
+        return $comparisonResult === 1 || $comparisonResult === 0;
+    }
+
+    /**
+     * Returns true if $this < $b, otherwise false
+     *
+     * @param  Decimal $b
+     * @param  integer $scale
+     * @return bool
+     */
+    public function isLessThan(Decimal $b, int $scale = null): bool
+    {
+        return $this->comp($b, $scale) === -1;
+    }
+
+    /**
+     * Returns true if $this <= $b, otherwise false
+     *
+     * @param  Decimal $b
+     * @param  integer $scale
+     * @return bool
+     */
+    public function isLessOrEqualTo(Decimal $b, int $scale = null): bool
+    {
+        $comparisonResult = $this->comp($b, $scale);
+
+        return $comparisonResult === -1 || $comparisonResult === 0;
+    }
+
     /**
      * Returns the element's additive inverse.
      * @return Decimal

--- a/tests/Decimal/DecimalIsGreaterOrEqualToTest.php
+++ b/tests/Decimal/DecimalIsGreaterOrEqualToTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+use Litipk\BigNumbers\Decimal;
+use PHPUnit\Framework\TestCase;
+
+class DecimalIsGreaterOrEqualToTest extends TestCase
+{
+    public function testGreater()
+    {
+        $this->assertTrue(Decimal::fromFloat(1.01)->isGreaterOrEqualTo(Decimal::fromFloat(1.001)));
+    }
+
+    public function testEqual()
+    {
+        $this->assertTrue(Decimal::fromFloat(1.001)->isGreaterOrEqualTo(Decimal::fromFloat(1.001)));
+    }
+
+    public function testLess()
+    {
+        $this->assertFalse(Decimal::fromFloat(1.001)->isGreaterOrEqualTo(Decimal::fromFloat(1.01)));
+    }
+}

--- a/tests/Decimal/DecimalIsGreaterThanTest.php
+++ b/tests/Decimal/DecimalIsGreaterThanTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+use Litipk\BigNumbers\Decimal;
+use PHPUnit\Framework\TestCase;
+
+class DecimalIsGreaterThanTest extends TestCase
+{
+    public function testGreater()
+    {
+        $this->assertTrue(Decimal::fromFloat(1.01)->isGreaterThan(Decimal::fromFloat(1.001)));
+    }
+
+    public function testEqual()
+    {
+        $this->assertFalse(Decimal::fromFloat(1.001)->isGreaterThan(Decimal::fromFloat(1.001)));
+    }
+
+    public function testLess()
+    {
+        $this->assertFalse(Decimal::fromFloat(1.001)->isGreaterThan(Decimal::fromFloat(1.01)));
+    }
+}

--- a/tests/Decimal/DecimalIsLessOrEqualToTest.php
+++ b/tests/Decimal/DecimalIsLessOrEqualToTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+use Litipk\BigNumbers\Decimal;
+use PHPUnit\Framework\TestCase;
+
+class DecimalIsLessOrEqualToTest extends TestCase
+{
+    public function testGreater()
+    {
+        $this->assertFalse(Decimal::fromFloat(1.01)->isLessOrEqualTo(Decimal::fromFloat(1.001)));
+    }
+
+    public function testEqual()
+    {
+        $this->assertTrue(Decimal::fromFloat(1.001)->isLessOrEqualTo(Decimal::fromFloat(1.001)));
+    }
+
+    public function testLess()
+    {
+        $this->assertTrue(Decimal::fromFloat(1.001)->isLessOrEqualTo(Decimal::fromFloat(1.01)));
+    }
+}

--- a/tests/Decimal/DecimalIsLessThanTest.php
+++ b/tests/Decimal/DecimalIsLessThanTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+use Litipk\BigNumbers\Decimal;
+use PHPUnit\Framework\TestCase;
+
+class DecimalIsLessThanTest extends TestCase
+{
+    public function testGreater()
+    {
+        $this->assertFalse(Decimal::fromFloat(1.01)->isLessThan(Decimal::fromFloat(1.001)));
+    }
+
+    public function testEqual()
+    {
+        $this->assertFalse(Decimal::fromFloat(1.001)->isLessThan(Decimal::fromFloat(1.001)));
+    }
+
+    public function testLess()
+    {
+        $this->assertTrue(Decimal::fromFloat(1.001)->isLessThan(Decimal::fromFloat(1.01)));
+    }
+}


### PR DESCRIPTION
This PR adds functions like `isGreaterOrEqualTo($b, $scale)`. Reason for these methods is readability.

I believe, that `$a->isGreaterThan($b)` is much easier to understand than `$a->comp($b) === 1`.

Let me know, what you think. I noticed that there currently is `equals()` method, so I'd be OK with renaming these functions to `$a->greaterThan($b)` (or maybe also adding `isEqualTo()`) for consistency.

Note: Wiki would also need to be updated.

Thanks for a great library & consideration of this contribution!