### PR TITLE
ISSUE-60: Fix for division by zero caused by float precision

### DIFF
--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -1203,6 +1203,7 @@ class Decimal
         switch ($cmp) {
             case 1:
                 $value_log10_approx = $value_len - ($in_scale > 0 ? ($in_scale+2) : 1);
+                $value_log10_approx = max(0, $value_log10_approx);
 
                 return \bcadd(
                     (string)$value_log10_approx,

--- a/tests/regression/issue60Test.php
+++ b/tests/regression/issue60Test.php
@@ -15,4 +15,13 @@ class issue60Test extends TestCase
         $this->assertEquals(0.05005, $value->div($divisor)->asFloat());
         $this->assertEquals(0.000434077479319, $value->log10()->asFloat());
     }
+
+    public function test_that_fromFloat_less_than_1_still_correct()
+    {
+        $value = Decimal::fromFloat(0.175);
+        $divisor = Decimal::fromFloat(20);
+
+        $this->assertEquals(0.009, $value->div($divisor)->asFloat());
+        $this->assertEquals(-0.7569, $value->log10()->asFloat());
+    }
 }

--- a/tests/regression/issue60Test.php
+++ b/tests/regression/issue60Test.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Litipk\BigNumbers\Decimal;
+use PHPUnit\Framework\TestCase;
+
+class issue60Test extends TestCase
+{
+    public function test_that_fromFloat_division_does_not_calculate_invalid_log10_avoiding_div_zero()
+    {
+        $value = Decimal::fromFloat(1.001);
+        $divisor = Decimal::fromFloat(20);
+
+        $this->assertEquals(0.05005, $value->div($divisor)->asFloat());
+        $this->assertEquals(0.000434077479319, $value->log10()->asFloat());
+    }
+}


### PR DESCRIPTION
Aims to resolve https://github.com/Litipk/php-bignumbers/issues/60

Note: This fix is based on my assumption that for numbers where the `$value_length` < `$in_scale + 1` the `$value_log10_approx` should be clamped to zero. This matches current test expectations (and log10 of the sample provided), but may be the incorrect place to address this (perhaps the natural scale for floats is the true source of this issue?)

## Proof/Testing
New regression test covering example case and asserting that log10 precision for affected case returns expected value.

Ping @castarco 