### PR TITLE
Use DC::one() in DC::e() to ensure DC::$ONE is initialized

### DIFF
--- a/src/DecimalConstants.php
+++ b/src/DecimalConstants.php
@@ -89,7 +89,7 @@ final class DecimalConstants
             throw new \InvalidArgumentException("\$scale must be positive.");
         }
 
-        return self::$ONE->exp($scale);
+        return static::one()->exp($scale);
     }
 
     /**


### PR DESCRIPTION
`DecimalConstant::e()` may be called while `DecimalConstant::$ONE` has not been initialized yet. Use `DecimalConstant::one()` to avoid the error.

