### PR TITLE
fromFloat: Ensure dot as decimal point.

### DIFF
--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -90,7 +90,7 @@ class Decimal
             throw new NaNInputError("fltValue can't be NaN");
         }
 
-        $strValue = (string) $fltValue;
+        $strValue = str_replace(',', '.', (string) $fltValue);
         $hasPoint = (false !== \strpos($strValue, '.'));
 
         if (\preg_match(self::EXP_NUM_GROUPS_NUMBER_REGEXP, $strValue, $capture)) {


### PR DESCRIPTION
String conversion is locale aware, because its primary use case
is for display purposes. This hack assumes that the only other
decimal point is a comma, which gets replaced by dot.

Alternatively, locale could be set to C before conversion and
restored after conversion, although this might incur an
performance penalty, because setlocale does I/O.