### PR TITLE
Implemented JsonSerializable

### DIFF
--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Litipk\BigNumbers;
 
+use JsonSerializable;
 use Litipk\BigNumbers\DecimalConstants as DecimalConstants;
 
 use Litipk\BigNumbers\Errors\InfiniteInputError;
@@ -14,7 +15,7 @@ use Litipk\BigNumbers\Errors\NotImplementedError;
  *
  * @author Andreu Correa Casablanca <castarco@litipk.com>
  */
-class Decimal
+class Decimal implements JsonSerializable
 {
     const DEFAULT_SCALE = 16;
     const CLASSIC_DECIMAL_NUMBER_REGEXP = '/^([+\-]?)0*(([1-9][0-9]*|[0-9])(\.[0-9]+)?)$/';
@@ -1125,6 +1126,14 @@ class Decimal
      * @return string
      */
     public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize(): string
     {
         return $this->value;
     }

--- a/tests/Decimal/DecimalJsonSerialize.php
+++ b/tests/Decimal/DecimalJsonSerialize.php
@@ -1,0 +1,19 @@
+<?php
+
+use Litipk\BigNumbers\Decimal as Decimal;
+use PHPUnit\Framework\TestCase;
+
+class DecimalJsonSerialize extends TestCase
+{
+    public function testJsonSerialize()
+    {
+        $value = '123.456';
+        $this->assertEquals($value, Decimal::fromString($value)->jsonSerialize());
+    }
+
+    public function testJsonSerializable()
+    {
+        $value = '123.456';
+        $this->assertEquals(json_encode($value), json_encode(Decimal::fromString($value)));
+    }
+}


### PR DESCRIPTION
This allows `Decimal` objects to be JSON serialized using `json_encode()`. They are serialized as their internal string representation since this is the most accurate.

Using `json_encode($decimal, JSON_NUMERIC_CHECK)` results in the decimal value being serialized as a JSON number, which might be desirable for some users. This might be worth documenting, though I'm not sure where would be best to put that.